### PR TITLE
docs: document GitLab 18 armhf→arm64 migration and memory-constrained guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 GitLab now officially supports ARM64 Docker images: https://hub.docker.com/r/gitlab/gitlab-ce
 Because of that, this repository is now in **read-only mode** and will not receive further updates.
 
+## Important note about GitLab 18 and CPU architecture
+
+GitLab 18 no longer provides the old **armhf** image variant. From GitLab 18 onward, the official ARM container support is **arm64**.
+
+If you are currently running GitLab 17 on armhf hardware, you cannot do an in-place package/image upgrade to GitLab 18 on the same armhf environment because the CPU architecture changed. A practical migration path is:
+
+1. Create a GitLab backup on your GitLab 17 instance.
+2. Move that backup to a machine that can run an x64 GitLab container.
+3. Restore the backup there and upgrade to GitLab 18.2.
+4. Create a new backup from the upgraded 18.2 instance.
+5. Restore that backup on your Raspberry Pi deployment using a GitLab CE 18.2 arm64 container.
+
+This architecture transition is one more reason this repository is not being updated further.
+
 the Dockerfile base on https://gitlab.com/gitlab-org/omnibus-gitlab/tree/master/docker
 and make some change for raspberry Pi
 
@@ -60,3 +74,6 @@ I observe this error occurred [link](https://gitlab.com/gitlab-org/omnibus-gitla
 [More Documents!](https://docs.gitlab.com/omnibus/docker/)
 
 The latest Docker guide can be found here: [GitLab Docker images](https://docs.gitlab.com/ee/install/docker.html).
+
+For low-hardware deployments, also review GitLab's official memory-constrained guidance:
+[Memory-constrained environments](https://docs.gitlab.com/omnibus/settings/memory_constrained_envs/).

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -7,6 +7,7 @@ services:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'https://gitlab.example.com'
         ###! See https://docs.gitlab.com/omnibus/settings/rpi.html
+        ###! See also https://docs.gitlab.com/omnibus/settings/memory_constrained_envs/
         # Reduce the number of running workers to the minimum in order to reduce memory usage
         puma['worker_processes'] = 0
         sidekiq['concurrency'] = 5


### PR DESCRIPTION
### Motivation
- GitLab 18 removed the `armhf` image and switched to `arm64`, which prevents in-place upgrades from GitLab 17 on armhf hardware and requires guidance for migrating backups across architectures.
- Provide official memory-constrained configuration guidance for low-hardware Raspberry Pi deployments.

### Description
- Added a new README section "Important note about GitLab 18 and CPU architecture" describing the architecture change and a step-by-step migration path using GitLab backups and restores across an x64 host and back to an `arm64` GitLab 18.2 container.
- Added a link to the official "Memory-constrained environments" documentation in `README.md` and referenced it in `docker-compose.yml.example`.

### Testing
- Verified the changes with `git diff -- README.md docker-compose.yml.example` and `git status --short`.
- Committed the documentation updates with `git commit -m "docs: clarify GitLab 18 architecture migration and low-memory guidance"`; no runtime tests were required because this is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1013a516083309eb1177a4024d741)