### PR TITLE
Polish README wording and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are running GitLab 17 on armhf hardware, you cannot perform an in-place u
 
 1. Create a backup on your GitLab 17 instance.
 2. Move that backup to a machine that can run an x64 GitLab container.
-3. Restore the backup there and upgrade to GitLab 18.2.
+3. Restore the backup to a matching GitLab 17 instance on the x64 machine, then upgrade that instance to GitLab 18.2.
 4. Create a new backup from the upgraded 18.2 instance.
 5. Restore that backup on your Raspberry Pi deployment using a GitLab CE 18.2 arm64 container.
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,47 @@
 # rpi-gitlab-ce
 
-**Project status: read-only**
+> **Project status: archived / read-only**
+>
+> GitLab now officially publishes ARM64 Docker images: <https://hub.docker.com/r/gitlab/gitlab-ce>.
+> Because of that, this repository is no longer maintained.
 
-GitLab now officially supports ARM64 Docker images: https://hub.docker.com/r/gitlab/gitlab-ce
-Because of that, this repository is now in **read-only mode** and will not receive further updates.
+## GitLab 18 architecture change (important)
 
-## Important note about GitLab 18 and CPU architecture
+Starting with GitLab 18, the old **armhf** image variant is no longer available. Official ARM container support is now **arm64** only.
 
-GitLab 18 no longer provides the old **armhf** image variant. From GitLab 18 onward, the official ARM container support is **arm64**.
+If you are running GitLab 17 on armhf hardware, you cannot perform an in-place upgrade to GitLab 18 on the same armhf environment. A practical migration path is:
 
-If you are currently running GitLab 17 on armhf hardware, you cannot do an in-place package/image upgrade to GitLab 18 on the same armhf environment because the CPU architecture changed. A practical migration path is:
-
-1. Create a GitLab backup on your GitLab 17 instance.
+1. Create a backup on your GitLab 17 instance.
 2. Move that backup to a machine that can run an x64 GitLab container.
 3. Restore the backup there and upgrade to GitLab 18.2.
 4. Create a new backup from the upgraded 18.2 instance.
 5. Restore that backup on your Raspberry Pi deployment using a GitLab CE 18.2 arm64 container.
 
-This architecture transition is one more reason this repository is not being updated further.
+This architecture transition is another reason this repository is archived.
 
-the Dockerfile base on https://gitlab.com/gitlab-org/omnibus-gitlab/tree/master/docker
-and make some change for raspberry Pi
+## Background
 
-I suggest enable the [zram](http://yulun.me/2015/enable-zram-for-raspberry-pi-debian/) to increase performance.
+This project was based on the upstream GitLab Omnibus Docker setup:
+<https://gitlab.com/gitlab-org/omnibus-gitlab/tree/master/docker>
+
+It includes Raspberry Pi-specific adjustments.
+
+For better performance on low-memory Raspberry Pi devices, consider enabling zram:
+<http://yulun.me/2015/enable-zram-for-raspberry-pi-debian/>
 
 ## Install Docker on Raspberry Pi
-[official documents link](https://docs.docker.com/install/linux/docker-ce/debian/#install-using-the-convenience-script)
+
+Official docs:
+<https://docs.docker.com/install/linux/docker-ce/debian/#install-using-the-convenience-script>
+
 ```bash
 curl -sSL https://get.docker.com | sh
 ```
 
-# Install & run container
-## Method 1 use pre-build image
+## Install and run the container
+
+### Method 1: Use prebuilt image
+
 ```bash
 sudo docker run --detach \
     --hostname IP \
@@ -44,8 +54,10 @@ sudo docker run --detach \
     jubilee2/rpi-gitlab-ce:v12.4.1
 ```
 
-## Method 2 build image by your self
-### Build Gitlab image:
+### Method 2: Build image yourself
+
+#### Build GitLab image
+
 ```bash
 sudo apt-get install git
 git clone https://github.com/jubilee2/rpi-gitlab-ce.git
@@ -53,7 +65,8 @@ cd rpi-gitlab-ce
 sudo docker build -t gitlab-ce .
 ```
 
-### Run Gitlab container:
+#### Run GitLab container
+
 ```bash
 sudo docker run --detach \
     --hostname IP \
@@ -66,14 +79,15 @@ sudo docker run --detach \
     gitlab-ce:latest
 ```
 
-# Experience
-It's need 20 min for first start up on my `raspberry PI 3 B+` with enable zram
-I observe this error occurred [link](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/common_installation_problems/README.md#failed-to-modify-kernel-parameters-with-sysctl), but after several automatic restarts, the initialization was completed.
+## Notes from prior Raspberry Pi usage
 
+- On a Raspberry Pi 3 B+ with zram enabled, first startup took about 20 minutes.
+- During startup, this known issue sometimes appeared:
+  <https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/common_installation_problems/README.md#failed-to-modify-kernel-parameters-with-sysctl>
+- In prior testing, initialization still completed after several automatic restarts.
 
-[More Documents!](https://docs.gitlab.com/omnibus/docker/)
+## Additional official documentation
 
-The latest Docker guide can be found here: [GitLab Docker images](https://docs.gitlab.com/ee/install/docker.html).
-
-For low-hardware deployments, also review GitLab's official memory-constrained guidance:
-[Memory-constrained environments](https://docs.gitlab.com/omnibus/settings/memory_constrained_envs/).
+- GitLab Omnibus Docker docs: <https://docs.gitlab.com/omnibus/docker/>
+- GitLab Docker install guide: <https://docs.gitlab.com/ee/install/docker.html>
+- Memory-constrained environments: <https://docs.gitlab.com/omnibus/settings/memory_constrained_envs/>


### PR DESCRIPTION
### Motivation

- Improve the repository `README.md` for clearer grammar, consistent headings, and easier scanning.
- Make the project's lifecycle status explicit by marking it as archived/read-only because upstream GitLab now publishes ARM64 images and GitLab 18 removes the old armhf variant.
- Clarify the armhf → arm64 migration path and keep existing operational guidance and links while improving phrasing.

### Description

- Rewrote `README.md` to reorganize content into clearer sections: project status, GitLab 18 architecture note, background, install/run instructions, usage notes, and additional documentation.
- Replaced the status line with `> **Project status: archived / read-only**` and added a link to the official ARM64 image on Docker Hub.
- Reformatted installation and runtime examples and renamed headings for consistency (e.g., `Method 1: Use prebuilt image`, `Method 2: Build image yourself`, `Build GitLab image`, `Run GitLab container`).
- Preserved original commands and external links and made a short recommendation to consider `zram` for low-memory Raspberry Pi devices.

### Testing

- Ran `git diff --check` with no issues reported.
- Verified the change with `git status --short` and inspected the patch with `git diff -- README.md`.
- Committed the updated `README.md` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e102b2fcc88330b4e4855ee1e2976e)