### PR TITLE
docs: add real-world backup/restore command example to UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -237,8 +237,8 @@ sudo chown jubilee2 1776397105_2026_04_17_17.11.7_gitlab_backup.tar
 ```bash
 scp 1776397105_2026_04_17_17.11.7_gitlab_backup.tar 192.168.1.91:~/
 # on target host:
-cp 1776397105_2026_04_17_17.11.7_gitlab_backup.tar /srv/gitlab/data/backups/
-docker exec -it rpi-gitlab-ce-web-1 chown git:git /var/opt/gitlab/backups/1776397105_2026_04_17_17.11.7_gitlab_backup.tar
+sudo cp 1776397105_2026_04_17_17.11.7_gitlab_backup.tar /srv/gitlab/data/backups/
+sudo docker exec -it rpi-gitlab-ce-web-1 chown git:git /var/opt/gitlab/backups/1776397105_2026_04_17_17.11.7_gitlab_backup.tar
 ```
 
 ### C) Restore that backup on target host

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -260,7 +260,7 @@ docker exec -it rpi-gitlab-ce-web-1 sh -lc 'GITLAB_ASSUME_YES=1 gitlab-backup re
 docker exec -t rpi-gitlab-ce-web-1 gitlab-backup create
 sudo docker cp rpi-gitlab-ce-web-1:/var/opt/gitlab/backups/1776400425_2026_04_17_18.2.8_gitlab_backup.tar .
 sudo chown jubilee2 1776400425_2026_04_17_18.2.8_gitlab_backup.tar
-scp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar 192.168.1.91:~/
+scp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar <local-machine-ip>:~/
 ```
 
 ### E) Final restore on destination machine

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -212,3 +212,61 @@ docker exec -it <x64-container-name> gitlab-backup create
 docker exec -it <arm64-container-name> gitlab-backup restore BACKUP=<backup_timestamp>
 ```
 
+---
+
+## 7) Real-world command log example (local → remote → local)
+
+If you prefer concrete commands, this is a cleaned-up version of an actual successful flow using container `rpi-gitlab-ce-web-1`.
+
+> Notes:
+>
+> - Replace hostnames/IPs and usernames (`jubilee2`, `192.168.1.91`) with your values.
+> - Replace backup filenames with the ones created on your run.
+> - `gitlab-backup restore` prompts for confirmation unless you set `GITLAB_ASSUME_YES=1`.
+
+### A) Create backup on source machine and pull it out of container
+
+```bash
+docker exec -t rpi-gitlab-ce-web-1 gitlab-backup create
+sudo docker cp rpi-gitlab-ce-web-1:/var/opt/gitlab/backups/1776397105_2026_04_17_17.11.7_gitlab_backup.tar .
+sudo chown jubilee2 1776397105_2026_04_17_17.11.7_gitlab_backup.tar
+```
+
+### B) Transfer backup to the target host and place it in GitLab backup path
+
+```bash
+scp 1776397105_2026_04_17_17.11.7_gitlab_backup.tar 192.168.1.91:~/
+# on target host:
+cp 1776397105_2026_04_17_17.11.7_gitlab_backup.tar /srv/gitlab/data/backups/
+docker exec -it rpi-gitlab-ce-web-1 chown git:git /var/opt/gitlab/backups/1776397105_2026_04_17_17.11.7_gitlab_backup.tar
+```
+
+### C) Restore that backup on target host
+
+```bash
+docker exec -it rpi-gitlab-ce-web-1 bash
+GITLAB_ASSUME_YES=1 gitlab-backup restore
+```
+
+You can also run restore directly without opening an interactive shell:
+
+```bash
+docker exec -it rpi-gitlab-ce-web-1 sh -lc 'GITLAB_ASSUME_YES=1 gitlab-backup restore'
+```
+
+### D) After upgrade, create a new backup and send it back
+
+```bash
+docker exec -t rpi-gitlab-ce-web-1 gitlab-backup create
+sudo docker cp rpi-gitlab-ce-web-1:/var/opt/gitlab/backups/1776400425_2026_04_17_18.2.8_gitlab_backup.tar .
+sudo chown jubilee2 1776400425_2026_04_17_18.2.8_gitlab_backup.tar
+scp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar 192.168.1.91:~/
+```
+
+### E) Final restore on destination machine
+
+```bash
+sudo cp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar /srv/gitlab/data/backups/
+sudo docker exec -it rpi-gitlab-ce-web-1 chown git:git /var/opt/gitlab/backups/1776400425_2026_04_17_18.2.8_gitlab_backup.tar
+sudo docker exec -it rpi-gitlab-ce-web-1 gitlab-backup restore
+```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -268,5 +268,5 @@ scp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar <local-machine-ip>:~/
 ```bash
 sudo cp 1776400425_2026_04_17_18.2.8_gitlab_backup.tar /srv/gitlab/data/backups/
 sudo docker exec -it rpi-gitlab-ce-web-1 chown git:git /var/opt/gitlab/backups/1776400425_2026_04_17_18.2.8_gitlab_backup.tar
-sudo docker exec -it rpi-gitlab-ce-web-1 gitlab-backup restore
+sudo docker exec -it rpi-gitlab-ce-web-1 sh -lc 'GITLAB_ASSUME_YES=1 gitlab-backup restore BACKUP=1776400425_2026_04_17_18.2.8'
 ```


### PR DESCRIPTION
### Motivation

- Provide a concrete, copy-paste backup/restore flow based on an actual successful run to make the upgrade guide easier to follow for users migrating armhf → x64 → arm64.
- Clarify common steps and pitfalls (copying backup files in/out of containers, ownership fixes, and non-interactive restore) so operators can reproduce the process reliably.

### Description

- Added a new "Real-world command log example (local → remote → local)" section to `UPGRADE.md` that walks through steps A–E (create backup, transfer, restore, upgrade and re-backup, final restore).
- Included explicit commands for extracting backups from the container (`docker cp`), creating backups (`docker exec -t ... gitlab-backup create`), fixing ownership (`chown git:git`), transferring with `scp`, and placing files into `/srv/gitlab/data/backups`.
- Documented both an interactive restore sequence and a one-liner non-interactive restore using `GITLAB_ASSUME_YES=1` and `docker exec ... sh -lc 'GITLAB_ASSUME_YES=1 gitlab-backup restore'`.
- Added notes advising replacement of hostnames/IPs, usernames, and backup filenames to match the user's environment.

### Testing

- Ran `git diff -- UPGRADE.md | sed -n '1,220p'` to verify the new section appears in the file diff and the inserted lines are present.
- Inspected the updated file layout with `nl -ba UPGRADE.md | sed -n '200,290p'` to confirm formatting and step ordering.
- Searched the repository with `rg -n "backup|restore|gitlab-backup|docker exec" .` to ensure the relevant commands are referenced consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1c11873248330a40d1a7825f68eb9)